### PR TITLE
add missing </i> closing tag

### DIFF
--- a/src/layout.html
+++ b/src/layout.html
@@ -9,7 +9,7 @@
   <body>
     <nav class="top-bar">
       <a href="/" class="top-bar-title">bret.io</a>
-      <a href="/cv" class="top-bar-link"><i class="fa fa-file-text"> cv</a>
+      <a href="/cv" class="top-bar-link"><i class="fa fa-file-text"></i> cv</a>
       <a href="/contact" class="top-bar-link"><i class="fa fa-comment"></i> contact</a>
 
       <div class="top-bar-right">


### PR DESCRIPTION
should correct a font-family error in your top bar once you rebuild